### PR TITLE
✨ feat(glossary): expose exactMatch on glossary types

### DIFF
--- a/src/types/glossary-create-request.ts
+++ b/src/types/glossary-create-request.ts
@@ -23,6 +23,12 @@ export type GlossaryCreateRequest = {
   caseSensitive: boolean;
 
   /**
+   * Whether the term must match exactly (as opposed to matching any inflected form).
+   * Defaults to `true` server-side when omitted.
+   */
+  exactMatch?: boolean;
+
+  /**
    * Contains an array of the term and it’s translations.
    */
   term: GlossaryRecordTerm[];

--- a/src/types/glossary-record.ts
+++ b/src/types/glossary-record.ts
@@ -22,6 +22,11 @@ export type GlossaryRecord = {
   caseSensitive: boolean;
 
   /**
+   * Whether the term must match exactly (as opposed to matching any inflected form).
+   */
+  exactMatch: boolean;
+
+  /**
    * Contains an array of the term and it’s translations.
    */
   term: GlossaryRecordTerm[];

--- a/src/types/glossary-update-request.ts
+++ b/src/types/glossary-update-request.ts
@@ -29,6 +29,12 @@ export type GlossaryUpdateRequest = {
   caseSensitive: boolean;
 
   /**
+   * Whether the term must match exactly (as opposed to matching any inflected form).
+   * Defaults to `true` server-side when omitted.
+   */
+  exactMatch?: boolean;
+
+  /**
    * Contains an array of the term and it’s translations.
    */
   term: GlossaryRecordTerm[];

--- a/tests/fixtures/full-project/glossary.json
+++ b/tests/fixtures/full-project/glossary.json
@@ -10,7 +10,8 @@
       ],
       "description": "A screen used for displaying visual output from a computer.",
       "translateTerm": false,
-      "caseSensitive": false
+      "caseSensitive": false,
+      "exactMatch": true
     }
   ]
 }

--- a/tests/specs/glossary.spec.ts
+++ b/tests/specs/glossary.spec.ts
@@ -32,6 +32,7 @@ describe('Glossary', (): void => {
     expect(firstRecord.description).toBe(
       'A screen used for displaying visual output from a computer.',
     );
+    expect(firstRecord.exactMatch).toBe(true);
   });
 
   test('api.glossary.find', async (): Promise<void> => {
@@ -94,6 +95,7 @@ describe('Glossary', (): void => {
       description: 'Exceptional term description',
       caseSensitive: true,
       translateTerm: true,
+      exactMatch: false,
       term: [{ lang: 'en', term: 'Exceptional term' }],
     };
     const spy: MockInstance = vi.spyOn(globalThis, 'fetch');
@@ -102,7 +104,7 @@ describe('Glossary', (): void => {
     expect(spy).toHaveBeenCalledWith(
       'https://api.localazy.com/projects/_a0000000000000000001/glossary/_a0000000000000000001',
       {
-        body: '{"description":"Exceptional term description","caseSensitive":true,"translateTerm":true,"term":[{"lang":"en","term":"Exceptional term"}]}',
+        body: '{"description":"Exceptional term description","caseSensitive":true,"translateTerm":true,"exactMatch":false,"term":[{"lang":"en","term":"Exceptional term"}]}',
         headers: {
           Accept: 'application/json',
           Authorization: `Bearer ${getToken()}`,


### PR DESCRIPTION
## What

Adds the `exactMatch` field to the glossary types, which the public API returns and accepts but the client didn't expose:

- `GlossaryRecord.exactMatch: boolean` — **required** (always present in responses)
- `GlossaryCreateRequest.exactMatch?: boolean` / `GlossaryUpdateRequest.exactMatch?: boolean` — **optional** (the public API defaults it to `true` when omitted)

Purely additive — no runtime change, no breaking change (ships as a minor).

## Why

Tracked in the in-context-editor's `external-items-and-missing-endpoints.md` §10. Verified against the backend source of truth (`server-backend/server-publicapi` → `PubApiGlossary`), which carries `exactMatch: Boolean = true`.

### Note on `lang` (intentionally unchanged)

§10 also claimed `GlossaryRecordTerm.lang` should be a numeric `langId`. That's **wrong for this client** and was **not** applied. This client targets the **public** API (`api.localazy.com` → `server-publicapi/PubApiGlossary`), where `term.lang` is a **`String` (locale code)** — matching the current typing and the [public docs](https://localazy.com/docs/api/glossary-endpoint). The numeric shape belongs to the **internal** app API (`server-api/Glossary`) that product-spa consumes. Changing `lang` to a number here would break the client against the real payload. The plugin doc has been corrected separately.

## Tests

- `api.glossary.list` now asserts `exactMatch` is read back
- `api.glossary.update` covers the provided-on-write serialization path
- Full suite green (`pnpm run check`): format, lint, typecheck, build, test

🤖 Generated with [Claude Code](https://claude.com/claude-code)